### PR TITLE
Add cssOrigin field for tabs.insertCSS details parameter.

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -505,6 +505,15 @@ declare namespace browser.extensionTypes {
         matchAboutBlank?: boolean,
         runAt?: RunAt,
     };
+    type InjectCssDetails = {
+        allFrames?: boolean,
+        code?: string,
+        cssOrigin?: string,
+        file?: string,
+        frameId?: number,
+        matchAboutBlank?: boolean,
+        runAt?: RunAt,
+    };
 }
 
 declare namespace browser.history {
@@ -1001,7 +1010,7 @@ declare namespace browser.tabs {
     //     windowId?: number,
     //     tabs: number[]|number,
     // }): Promise<browser.windows.Window>;
-    function insertCSS(tabId: number|undefined, details: browser.extensionTypes.InjectDetails): Promise<void>;
+    function insertCSS(tabId: number|undefined, details: browser.extensionTypes.InjectCssDetails): Promise<void>;
     function removeCSS(tabId: number|undefined, details: browser.extensionTypes.InjectDetails): Promise<void>;
     function move(tabIds: number|number[], moveProperties: {
         windowId?: number,


### PR DESCRIPTION
The field is unique to tabs.insertCSS, so I added a new InjectCssDetails type to
provide it. I would have liked to do something like:
`type InjectCssDetails extends InjectDetails = {
    cssOrigin?: string,
}`
to reduce repetition, but I couldn't find a way to make it work. New to Typescript, so I could be missing something.