### PR TITLE
Optional parameters for browser.tabs.reload()

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -1032,7 +1032,7 @@ declare namespace browser.tabs {
         windowId?: number,
         windowType?: WindowType,
     }): Promise<Tab[]>;
-    function reload(tabId: number, reloadProperties: { bypassCache: boolean }): Promise<void>;
+    function reload(tabId?: number, reloadProperties?: { bypassCache?: boolean }): Promise<void>;
     function remove(tabIds: number|number[]): Promise<void>;
     function saveAsPDF(pageSettings: PageSettings): Promise<
         'saved' |


### PR DESCRIPTION
The function parameters for browser.tabs.reload() are optional as per https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/reload