### PR TITLE
Add optional types to browser.runtime.sendMessage() and browser.tabs.sendMessage()

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ TypeScript type definitions for WebExtensions, based on MDN's documentation.
 
 ## Requirements
 
-As this library is using the `object` type, `typescript` should at least be on
-version `2.2` to get the definitions to work.
+As this library is using the `object` type and default values for generics,
+`typescript` should at least be on version `2.3` to get the definitions to work.
 
 ## Install it
 

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -735,22 +735,22 @@ declare namespace browser.runtime {
     ): Port;
     function connectNative(application: string): Port;
 
-    function sendMessage(
-        message: any
-    ): Promise<any>;
-    function sendMessage(
-        message: any,
+    function sendMessage<T = any, U = any>(
+        message: T
+    ): Promise<U>;
+    function sendMessage<T = any, U = any>(
+        message: T,
         options: { includeTlsChannelId?: boolean, toProxyScript?: boolean }
-    ): Promise<any>;
-    function sendMessage(
+    ): Promise<U>;
+    function sendMessage<T = any, U = any>(
         extensionId: string,
-        message: any,
-    ): Promise<any>;
-    function sendMessage(
+        message: T,
+    ): Promise<U>;
+    function sendMessage<T = any, U = any>(
         extensionId: string,
-        message: any,
+        message: T,
         options?: { includeTlsChannelId?: boolean, toProxyScript?: boolean }
-    ): Promise<any>;
+    ): Promise<U>;
 
     function sendNativeMessage(
         application: string,
@@ -1041,7 +1041,7 @@ declare namespace browser.tabs {
         'not_saved' |
         'not_replaced'
     >;
-    function sendMessage(tabId: number, message: any, options?: { frameId?: number }): Promise<object|void>;
+    function sendMessage<T = any, U = object>(tabId: number, message: T, options?: { frameId?: number }): Promise<U|void>;
     // deprecated: function sendRequest(): x;
     function setZoom(tabId: number|undefined, zoomFactor: number): Promise<void>;
     function setZoomSettings(tabId: number|undefined, zoomSettings: ZoomSettings): Promise<void>;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "license": "MPL-2.0",
     "devDependencies": {
         "tslint": "4.5.1",
-        "typescript": "2.2.1"
+        "typescript": "2.3.0"
     },
     "scripts": {
         "lint": "tslint --project tsconfig.json",


### PR DESCRIPTION
Currently, all the messages and return values are typed as `any` or `object`. This change gives the consumer the option of providing explicit types, for additional type checking.