### PR TITLE
Add permissions API

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -680,6 +680,34 @@ declare namespace browser.pageAction {
     const onClicked: Listener<browser.tabs.Tab>;
 }
 
+declare namespace browser.permissions {
+    type Permission = "activeTab" | "alarms" |
+        "bookmarks" | "browsingData" | "browserSettings" |
+        "contextMenus" | "contextualIdentities" | "cookies" |
+        "downloads" | "downloads.open" |
+        "find" | "geolocation" | "history" |
+        "identity" | "idle" |
+        "management" | "menus" |
+        "nativeMessaging" | "notifications" |
+        "pkcs11" | "privacy" | "proxy" |
+        "sessions" | "storage" |
+        "tabs" | "theme" | "topSites" |
+        "webNavigation" | "webRequest" | "webRequestBlocking";
+
+    type Permissions = {
+        origins?: string[],
+        permissions?: Permission[]
+    };
+
+    function contains(permissions: Permissions): Promise<boolean>;
+
+    function getAll(): Promise<Permissions>;
+
+    function remove(permissions: Permissions): Promise<boolean>;
+
+    function request(permissions: Permissions): Promise<boolean>;
+}
+
 declare namespace browser.runtime {
     const lastError: string | null;
     const id: string;

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -707,8 +707,9 @@ declare namespace browser.permissions {
 
     function request(permissions: Permissions): Promise<boolean>;
 
-    const onAdded: Listener<Permissions>;
-    const onRemoved: Listener<Permissions>;
+    // Not yet support in Edge and Firefox:
+    // const onAdded: Listener<Permissions>;
+    // const onRemoved: Listener<Permissions>;
 }
 
 declare namespace browser.runtime {

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -706,6 +706,9 @@ declare namespace browser.permissions {
     function remove(permissions: Permissions): Promise<boolean>;
 
     function request(permissions: Permissions): Promise<boolean>;
+
+    const onAdded: Listener<Permissions>;
+    const onRemoved: Listener<Permissions>;
 }
 
 declare namespace browser.runtime {


### PR DESCRIPTION
The [permissions API](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/permissions) was still missing in web-ext-types.