### PR TITLE
Added better typscript definition detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,6 @@
         "lint": "tslint --project tsconfig.json",
         "prepublish": "tsc",
         "test": "tslint --project tsconfig.json && tsc"
-    }
+    },
+    "types": "global/index.d.ts"
 }


### PR DESCRIPTION
By adding a `types` property to the `package.json` the defintion via can be referenced like this:

    /// <reference types="web-ext-types" />

instead of requiring a direct reference or adding the source folder to the type roots.