### PR TITLE
Add the ability to type storage objects

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -938,7 +938,7 @@ declare namespace browser.storage {
     interface StorageSet extends Set<StorageValue> {}
 
     interface Get {
-        (keys?: string|string[]|null): Promise<StorageObject>;
+        <T extends StorageObject>(keys?: string|string[]|null): Promise<T>;
         /* <T extends StorageObject>(keys: T): Promise<{[K in keyof T]: T[K]}>; */
         <T extends StorageObject>(keys: T): Promise<T>;
     }


### PR DESCRIPTION
For example if you have defined a type for the data stored, like this: 

``` ts
type settings = {
    items: string[]
}
```

You can have it already typed out of the storage:
``` ts
browser.storage.sync.get<settings>("test").then((data) => {
    data.items // data is typed with settings
})
```

Existing usage won't be bothered since `T` is a `StorageObject` by default.
