### PR TITLE
Several fixes for the type definitions

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -747,11 +747,11 @@ declare namespace browser.runtime {
         error: object,
         onDisconnect: {
             addListener(cb: (port: Port) => void): void,
-            removeListener(): void,
+            removeListener(cb: (port: Port) => void): void,
         },
         onMessage: {
             addListener(cb: (message: object) => void): void,
-            removeListener(): void,
+            removeListener(cb: (message: object) => void): void,
         },
         postMessage(message: object): void,
         sender?: runtime.MessageSender,

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -303,6 +303,26 @@ declare namespace browser.cookies {
     const onChanged: Listener<{ removed: boolean, cookie: Cookie, cause: OnChangedCause }>;
 }
 
+declare namespace browser.contentScripts {
+	type RegisteredContentScriptOptions = {
+		allFrames?: boolean,
+		css?: ({ file: string }|{ code: string })[],
+		excludeGlobs?: string[],
+		excludeMatches?: string[],
+		includeGlobs?: string[],
+		js?: ({ file: string }|{ code: string })[],
+		matchAboutBlank?: boolean,
+		matches: string[],
+		runAt?: 'document_start' | 'document_end' | 'document_idle',
+	};
+	
+	type RegisteredContentScript = {
+		unregister: () => void;
+	};
+	
+	function register(contentScriptOptions: RegisteredContentScriptOptions): Promise<RegisteredContentScript>;
+}
+
 declare namespace browser.devtools.inspectedWindow {
     const tabId: number;
 

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -103,25 +103,20 @@ declare namespace browser.browserAction {
     type ColorArray = [number, number, number, number];
     type ImageDataType = ImageData;
 
-    function setTitle(details: { title: string, tabId?: number }): void;
+    function setTitle(details: { title: string|null, tabId?: number }): void;
     function getTitle(details: { tabId?: number }): Promise<string>;
 
-    type IconViaPath = {
-        path: string | object,
-        tabId?: number,
-    };
-
-    type IconViaImageData = {
-        imageData: ImageDataType,
-        tabId?: number,
-    };
-    function setIcon(details: IconViaPath | IconViaImageData): Promise<void>;
-    function setPopup(details: { popup: string, tabId?: number }): void;
+    function setIcon(details: {
+        imageData?: ImageDataType|{}|null|undefined,
+        path?: string|{}|null|undefined,
+        tabId?: number
+    }): Promise<void>;
+    function setPopup(details: { popup: string|null, tabId?: number }): void;
     function getPopup(details: { tabId?: number }): Promise<string>;
     function openPopup(): Promise<void>;
-    function setBadgeText(details: { text: string, tabId?: number }): void;
+    function setBadgeText(details: { text: string|null, tabId?: number }): void;
     function getBadgeText(details: { tabId?: number }): Promise<string>;
-    function setBadgeBackgroundColor(details: { color: string|ColorArray, tabId?: number }): void;
+    function setBadgeBackgroundColor(details: { color: string|ColorArray|null, tabId?: number }): void;
     function getBadgeBackgroundColor(details: { tabId?: number }): Promise<ColorArray>;
     function enable(tabId?: number): void;
     function disable(tabId?: number): void;


### PR DESCRIPTION
Thank you for providing this definition file! While using it I encountered some minor issues that I hereby provide fixes for:

 * Fix issue with unregistering listeners from `browser.runtime.Port` events
 * Add support for `browser.contentScripts`
 * Add support for the “reset to default” invocation syntaxes of `browser.browserAction`