### PR TITLE
Added type property to bookmark CreateDetails

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -54,6 +54,7 @@ declare namespace browser.bookmarks {
     parentId?: string;
     index?: number;
     title?: string;
+    type?: BookmarkTreeNodeType;
     url?: string;
   };
 


### PR DESCRIPTION
`CreateDetails` has a `type` property: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/bookmarks/CreateDetails#type