### PR TITLE
Added missing definitions

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -1575,6 +1575,9 @@ declare namespace browser.tabs {
     tabId: number | undefined,
     zoomSettings: ZoomSettings
   ): Promise<void>;
+  function toggleReaderMode(
+    tabId?:number
+  ):Promise<void>;
   function update(
     tabId: number | undefined,
     updateProperties: {

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -2070,6 +2070,7 @@ declare namespace browser.windows {
 
   // TODO: url and tabId should be exclusive
   function create(createData?: {
+    allowScriptsToClose?:boolean;
     url?: string | string[];
     tabId?: number;
     left?: number;
@@ -2078,6 +2079,7 @@ declare namespace browser.windows {
     height?: number;
     // unsupported: focused?: boolean,
     incognito?: boolean;
+    titlePreface?:string;
     type?: CreateType;
     state?: WindowState;
   }): Promise<browser.windows.Window>;


### PR DESCRIPTION
There were two properties missing: `allowScriptsToClose` and `titlePreface`.
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/windows/create

Also please update the npm version :)