### PR TITLE
Small fix to webRequest BlockingResponse

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -1820,7 +1820,7 @@ declare namespace browser.webRequest {
     redirectUrl?: string;
     requestHeaders?: HttpHeaders;
     responseHeaders?: HttpHeaders;
-    // unsupported: authCredentials?: { username: string, password: string },
+    authCredentials?: { username: string, password: string };
   };
 
   type UploadData = {


### PR DESCRIPTION
Not sure why the authCredentials is commented out as unsupported. 

It is defined here: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webRequest/BlockingResponse