### PR TITLE
fix(notifications): overload "create" function

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -815,6 +815,7 @@ declare namespace browser.notifications {
     id: string | null,
     options: NotificationOptions
   ): Promise<string>;
+  function create(options: NotificationOptions): Promise<string>;
 
   function clear(id: string): Promise<boolean>;
 


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/create#Parameters

First parameter (`id`) is optional and can be not used, eg:
```js
chrome.notifications.create({ type: 'basic', ... })
```