### PR TITLE
Add support for tabhiding features.

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -1454,6 +1454,7 @@ declare namespace browser.tabs {
     discarded?: boolean;
     favIconUrl?: string;
     height?: number;
+    hidden: boolean;
     highlighted: boolean;
     id?: number;
     incognito: boolean;
@@ -1547,6 +1548,7 @@ declare namespace browser.tabs {
     cookieStoreId?: string;
     currentWindow?: boolean;
     discarded?: boolean;
+    hidden?: boolean;
     highlighted?: boolean;
     index?: number;
     muted?: boolean;
@@ -1589,6 +1591,7 @@ declare namespace browser.tabs {
       active?: boolean;
       // unsupported: autoDiscardable?: boolean,
       // unsupported: highlighted?: boolean,
+      hidden?: boolean;
       loadReplace?: boolean;
       muted?: boolean;
       openerTabId?: number;

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -1591,7 +1591,7 @@ declare namespace browser.tabs {
       active?: boolean;
       // unsupported: autoDiscardable?: boolean,
       // unsupported: highlighted?: boolean,
-      hidden?: boolean;
+      // unsupported: hidden?: boolean;
       loadReplace?: boolean;
       muted?: boolean;
       openerTabId?: number;

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -1520,6 +1520,7 @@ declare namespace browser.tabs {
   // deprecated: function getSelected(windowId?: number): Promise<browser.tabs.Tab>;
   function getZoom(tabId?: number): Promise<number>;
   function getZoomSettings(tabId?: number): Promise<ZoomSettings>;
+  function hide(tabIds: number | number[]): Promise<number[]>;
   // unsupported: function highlight(highlightInfo: {
   //     windowId?: number,
   //     tabs: number[]|number,
@@ -1582,6 +1583,7 @@ declare namespace browser.tabs {
     tabId: number | undefined,
     zoomSettings: ZoomSettings
   ): Promise<void>;
+  function show(tabIds: number | number[]): Promise<void>;
   function toggleReaderMode(
     tabId?:number
   ):Promise<void>;


### PR DESCRIPTION
Two new functions in the `browser.tabs` namespace `hide` and `show`. `browser.tabs.Tab` has a new `hidden` boolean property and `browser.tabs.query` got updated as well to reflect that.