### PR TITLE
Fix/browser menus

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -266,23 +266,26 @@ declare namespace browser.contextMenus {
 
   function create(
     createProperties: {
-      type?: ItemType;
-      id?: string;
-      title?: string;
       checked?: boolean;
       command?:
         | "_execute_browser_action"
         | "_execute_page_action"
         | "_execute_sidebar_action";
       contexts?: ContextType[];
+      documentUrlPatterns?: string[];
+      enabled?: boolean;
+      icons?: object;
+      id?: string;
       onclick?: (info: OnClickData, tab: browser.tabs.Tab) => void;
       parentId?: number | string;
-      documentUrlPatterns?: string[];
       targetUrlPatterns?: string[];
-      enabled?: boolean;
+      title?: string;
+      type?: ItemType;
+      visible?: boolean;
     },
     callback?: () => void
   ): number | string;
+
   function update(
     id: number | string,
     updateProperties: {

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -317,6 +317,10 @@ declare namespace browser.contextMenus {
   const onClicked: EvListener<
     (info: OnClickData, tab: browser.tabs.Tab) => void
   >;
+
+  const onHidden: EvListener<() => void>;
+
+  const onShown: EvListener<(info: OnClickData, tab: browser.tabs.Tab) => void>;
 }
 
 declare namespace browser.contextualIdentities {

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -225,20 +225,21 @@ declare namespace browser.commands {
 declare namespace browser.contextMenus {
   type ContextType =
     | "all"
-    | "page"
-    | "frame"
-    | "page"
-    | "link"
-    | "editable"
-    | "image"
-    | "selection"
-    | "video"
     | "audio"
-    | "launcher"
+    | "bookmarks"
     | "browser_action"
+    | "editable"
+    | "frame"
+    | "image"
+    // | "launcher" unsupported
+    | "link"
+    | "page"
     | "page_action"
     | "password"
-    | "tab";
+    | "selection"
+    | "tab"
+    | "tools_menu"
+    | "video";
 
   type ItemType = "normal" | "checkbox" | "radio" | "separator";
 

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -286,6 +286,14 @@ declare namespace browser.contextMenus {
     callback?: () => void
   ): number | string;
 
+  function getTargetElement(targetElementId: number): object | null;
+
+  function refresh(): Promise<void>;
+
+  function remove(menuItemId: number | string): Promise<void>;
+
+  function removeAll(): Promise<void>;
+
   function update(
     id: number | string,
     updateProperties: {
@@ -300,8 +308,6 @@ declare namespace browser.contextMenus {
       enabled?: boolean;
     }
   ): Promise<void>;
-  function remove(menuItemId: number | string): Promise<void>;
-  function removeAll(): Promise<void>;
 
   const onClicked: EvListener<
     (info: OnClickData, tab: browser.tabs.Tab) => void

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -244,18 +244,22 @@ declare namespace browser.contextMenus {
   type ItemType = "normal" | "checkbox" | "radio" | "separator";
 
   type OnClickData = {
+    bookmarkId?: string;
+    checked?: boolean;
+    editable: boolean;
+    frameId?: number;
+    frameUrl?: string;
+    linkText?: string;
+    linkUrl?: string;
+    mediaType?: string;
     menuItemId: number | string;
     modifiers: string[];
-    editable: boolean;
-    parentMenuItemId?: number | string;
-    mediaType?: string;
-    linkUrl?: string;
-    srcUrl?: string;
     pageUrl?: string;
-    frameUrl?: string;
+    parentMenuItemId?: number | string;
     selectionText?: string;
+    srcUrl?: string;
+    targetElementId?: number;
     wasChecked?: boolean;
-    checked?: boolean;
   };
 
   const ACTION_MENU_TOP_LEVEL_LIMIT: number;

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -297,15 +297,20 @@ declare namespace browser.contextMenus {
   function update(
     id: number | string,
     updateProperties: {
-      type?: ItemType;
-      title?: string;
       checked?: boolean;
+      command?:
+        | "_execute_browser_action"
+        | "_execute_page_action"
+        | "_execute_sidebar_action";
       contexts?: ContextType[];
+      documentUrlPatterns?: string[];
+      enabled?: boolean;
       onclick?: (info: OnClickData, tab: browser.tabs.Tab) => void;
       parentId?: number | string;
-      documentUrlPatterns?: string[];
       targetUrlPatterns?: string[];
-      enabled?: boolean;
+      title?: string;
+      type?: ItemType;
+      visible?: boolean;
     }
   ): Promise<void>;
 

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -222,7 +222,7 @@ declare namespace browser.commands {
   const onCommand: Listener<string>;
 }
 
-declare namespace browser.contextMenus {
+declare namespace browser.menus {
   type ContextType =
     | "all"
     | "audio"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-ext-types",
   "author": "Kelsey Zapata <key@kelseasy.org> (https://kelseyz.org)",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "TypeScript type definitions for WebExtensions",
   "keywords": [
     "firefox",


### PR DESCRIPTION
### fix(menus): add missing ContextTypes

And order alphabetically while we're at it

### fix(menus): add missing OnClickData fields

### fix(menus.create): add missing updateProperties

### feat(browser.menus): add refresh function

Move the removal function in alphabetical order too

### fix(browser.menus): add missing fields in update()

### feat(browser.menus): add missing event listeners

### fix(browser.menus): change namespace

I don't know why mozilla decided to deviate from the norm there, weird

This is a breaking change, obviously

### chore(yarn): update version

As there is a breaking change, the major goes up.

