### PR TITLE
Fix runtime.connect argument

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -1323,6 +1323,9 @@ declare namespace browser.runtime {
   // Will not exist: https://bugzilla.mozilla.org/show_bug.cgi?id=1314922
   // function RequestUpdateCheck(): Promise<RequestUpdateCheckStatus>;
   function connect(
+    connectInfo?: { name?: string; includeTlsChannelId?: boolean }
+  ): Port;
+  function connect(
     extensionId?: string,
     connectInfo?: { name?: string; includeTlsChannelId?: boolean }
   ): Port;


### PR DESCRIPTION
Function overload is needed since both arguments are optional. See the [example](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/connect#Examples) on MDN.